### PR TITLE
✨ feat(root): improve web check signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ pnpm-debug.log*
 .vscode/
 .cursor/
 .vite-hooks/
+.wrangler/
 .learnings/

--- a/apps/root/public/.well-known/security.txt
+++ b/apps/root/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:zrr1999@qq.com
+Expires: 2027-06-18T00:00:00Z
+Preferred-Languages: zh, en
+Canonical: https://zrr.dev/.well-known/security.txt

--- a/apps/root/public/sitemap.xml
+++ b/apps/root/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://zrr.dev/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/apps/root/src/components/Layout.astro
+++ b/apps/root/src/components/Layout.astro
@@ -10,16 +10,31 @@ const {
   title = "六个骨头的个人主页",
   description = "六个骨头的个人网站主页，包含博客、幻灯片等内容",
 } = Astro.props;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? "https://zrr.dev");
 ---
 
 <!doctype html>
-<html lang="zh-cn">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="author" content="Zhan Rongrui" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#f7f1e8" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="generator" content={Astro.generator} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl.href} />
+    <meta property="og:site_name" content="zrr.dev" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
     <title>{title}</title>
+    <link rel="canonical" href={canonicalUrl.href} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/root/src/worker.ts
+++ b/apps/root/src/worker.ts
@@ -1,0 +1,88 @@
+/// <reference lib="es2022" />
+
+interface AssetFetcher {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+interface Env {
+  ASSETS: AssetFetcher;
+}
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "img-src 'self' data: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
+  "connect-src 'self' https://challenges.cloudflare.com",
+  "frame-src 'self' https://challenges.cloudflare.com",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const SECURITY_HEADERS = {
+  "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Permissions-Policy": [
+    "accelerometer=()",
+    "camera=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "magnetometer=()",
+    "microphone=()",
+    "payment=()",
+    "usb=()",
+  ].join(", "),
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "X-XSS-Protection": "0",
+} as const;
+
+const IMMUTABLE_ASSET_PATH =
+  /^\/_astro\/.+\.(?:css|js|mjs|png|jpe?g|webp|avif|gif|svg|ico|woff2?)$/i;
+const STATIC_ASSET_PATH =
+  /\.(?:css|js|mjs|png|jpe?g|webp|avif|gif|svg|ico|woff2?|txt|xml)$/i;
+
+function appendHeaders(request: Request, response: Response): Response {
+  const securedResponse = new Response(response.body, response);
+
+  for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+    securedResponse.headers.set(header, value);
+  }
+
+  const { pathname } = new URL(request.url);
+  if (response.ok && IMMUTABLE_ASSET_PATH.test(pathname)) {
+    securedResponse.headers.set(
+      "Cache-Control",
+      "public, max-age=31536000, immutable"
+    );
+  } else if (response.ok && STATIC_ASSET_PATH.test(pathname)) {
+    securedResponse.headers.set("Cache-Control", "public, max-age=86400");
+  }
+
+  return securedResponse;
+}
+
+function redirectToApex(request: Request): Response | undefined {
+  const url = new URL(request.url);
+  if (url.hostname !== "www.zrr.dev") return undefined;
+
+  url.hostname = "zrr.dev";
+  const response = Response.redirect(url, 308);
+  return appendHeaders(request, response);
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const redirect = redirectToApex(request);
+    if (redirect) return redirect;
+
+    const response = await env.ASSETS.fetch(request);
+    return appendHeaders(request, response);
+  },
+};

--- a/apps/root/tsconfig.json
+++ b/apps/root/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "paths": {
       "@/*": ["src/*"]
     }

--- a/apps/root/wrangler.jsonc
+++ b/apps/root/wrangler.jsonc
@@ -2,8 +2,11 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "zrr-website-root",
   "compatibility_date": "2026-05-08",
+  "main": "./src/worker.ts",
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": true,
   },
   "routes": [
     {


### PR DESCRIPTION
## Summary
- Add a root Worker wrapper to attach security headers, asset cache headers, and a `www.zrr.dev` → `zrr.dev` 308 redirect.
- Add root SEO/social metadata, canonical URL, sitemap, and security.txt.
- Ignore local Wrangler cache output.

## Validation
- `env CI=true vp fmt . --check` in `apps/root`
- `env CI=true vp lint .` in `apps/root`
- `env CI=true vp run build:cf:root`
- `env CI=true vp exec wrangler deploy --cwd apps/root --dry-run`
- Pre-commit `vp check --fix` passed during commit

## Notes
- DNSSEC, DMARC, and old-domain Cloudflare redirect rules still need Cloudflare dashboard/DNS changes outside this code PR.
